### PR TITLE
The js in SeleniumTestReporter.html is broken when test name has characters like chinese

### DIFF
--- a/src/main/java/com/seleniumtests/helper/StringUtility.java
+++ b/src/main/java/com/seleniumtests/helper/StringUtility.java
@@ -13,7 +13,10 @@
 
 package com.seleniumtests.helper;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 public class StringUtility {
 
@@ -42,5 +45,43 @@ public class StringUtility {
         }
 
         return sbParam.toString();
+    }
+
+    public static String md5(final String str) {
+
+        if (str == null) {
+            return null;
+        }
+
+        MessageDigest messageDigest = null;
+
+        try {
+            messageDigest = MessageDigest.getInstance("MD5");
+            messageDigest.reset();
+            messageDigest.update(str.getBytes("UTF-8"));
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            return str;
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+            return str;
+        }
+
+        byte[] byteArray = messageDigest.digest();
+
+        return toHexString(byteArray);
+    }
+
+    public static String toHexString(byte[] byteArray) {
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < byteArray.length; i++) {
+            if (Integer.toHexString(0xFF & byteArray[i]).length() == 1)
+                builder.append("0").append(Integer.toHexString(0xFF & byteArray[i]));
+            else
+                builder.append(Integer.toHexString(0xFF & byteArray[i]));
+        }
+
+        return builder.toString();
     }
 }

--- a/src/main/java/com/seleniumtests/reporter/SeleniumTestsReporter.java
+++ b/src/main/java/com/seleniumtests/reporter/SeleniumTestsReporter.java
@@ -700,16 +700,8 @@ public class SeleniumTestsReporter implements IReporter, ITestListener, IInvoked
 
             m_out = createWriter(getOutputDirectory());
             startHtml(testCtx, m_out);
-
-            int i = 0;
-            for (ISuite suite : suites) {
-                List<ISuite> singleSuiteList = new ArrayList<ISuite>();
-                singleSuiteList.add(suite);
-                generateSuiteSummaryReport(singleSuiteList, xml.get(i).getName());
-                generateReportsSection(singleSuiteList);
-                i++;
-            }
-            
+            generateSuiteSummaryReport(suites, xml.get(0).getName());
+            generateReportsSection(suites);
             endHtml(m_out);
             m_out.flush();
             m_out.close();

--- a/src/main/java/com/seleniumtests/reporter/SeleniumTestsReporter.java
+++ b/src/main/java/com/seleniumtests/reporter/SeleniumTestsReporter.java
@@ -731,7 +731,7 @@ public class SeleniumTestsReporter implements IReporter, ITestListener, IInvoked
 
             Template t = ve.getTemplate("/templates/report.part.testDetail.html");
             VelocityContext context = new VelocityContext();
-            context.put("testId", name.toLowerCase().replace(' ', '_').replace('(', '_').replace(')', '_'));
+            context.put("testId", StringUtility.md5(name);
             context.put("testName", name);
             context.put("envtp", envtp);
             context.put("envtf", envtf);

--- a/src/main/java/com/seleniumtests/reporter/SeleniumTestsReporter.java
+++ b/src/main/java/com/seleniumtests/reporter/SeleniumTestsReporter.java
@@ -700,8 +700,16 @@ public class SeleniumTestsReporter implements IReporter, ITestListener, IInvoked
 
             m_out = createWriter(getOutputDirectory());
             startHtml(testCtx, m_out);
-            generateSuiteSummaryReport(suites, xml.get(0).getName());
-            generateReportsSection(suites);
+
+            int i = 0;
+            for (ISuite suite : suites) {
+                List<ISuite> singleSuiteList = new ArrayList<ISuite>();
+                singleSuiteList.add(suite);
+                generateSuiteSummaryReport(singleSuiteList, xml.get(i).getName());
+                generateReportsSection(singleSuiteList);
+                i++;
+            }
+            
             endHtml(m_out);
             m_out.flush();
             m_out.close();

--- a/src/main/java/com/seleniumtests/reporter/ShortTestResult.java
+++ b/src/main/java/com/seleniumtests/reporter/ShortTestResult.java
@@ -13,6 +13,8 @@
 
 package com.seleniumtests.reporter;
 
+import com.seleniumtests.helper.StringUtility;
+
 public class ShortTestResult {
 
     private String name;
@@ -28,7 +30,7 @@ public class ShortTestResult {
 
     public ShortTestResult(final String name) {
         this.name = name;
-        this.id = name.toLowerCase().replaceAll(" ", "_");
+        this.id = StringUtility.md5(name);
     }
 
     public String getId() {


### PR DESCRIPTION
Fix: The js in SeleniumTestReporter.html is broken when test name has characters like chinese, japanese,etc.

Attribute ID in HTML TAGS should not contain characters like chinese, otherwise js cannot locate this element.  The fix is to use md5 digest to generate an ID for test names.